### PR TITLE
修复了拦截ajax请求的时候没有附带浏览器UA的问题

### DIFF
--- a/Sources/Private/HookAjax/WKUserContentController+IMYHookAjax.m
+++ b/Sources/Private/HookAjax/WKUserContentController+IMYHookAjax.m
@@ -28,17 +28,28 @@
     id requestID = body[@"id"];
     NSString *method = body[@"method"];
     id requestData = body[@"data"];
-    NSDictionary *requestHeaders = body[@"headers"];
+    NSMutableDictionary *requestHeaders = [NSMutableDictionary dictionaryWithDictionary:body[@"headers"]];
     NSString *urlString = body[@"url"];
     
-    [[IMYWebLoader defaultAjaxHandler] startWithMethod:method
-                                                   url:urlString
-                                               baseURL:self.webView.URL
-                                               headers:requestHeaders
-                                                  body:requestData
-                                        completedBlock:^(NSInteger httpCode, NSDictionary * _Nullable headers, NSString * _Nullable data) {
-                                            [self requestCallback:requestID httpCode:httpCode headers:headers data:data];
-                                        }];
+    //这里模拟Webview请求的时候的ua
+    [self.webView evaluateJavaScript:@"navigator.userAgent" completionHandler:^(id result, NSError *error) {
+        
+        NSString *webviewUA = result;
+        if (webviewUA) requestHeaders[@"User-Agent"] = webviewUA;
+        
+        
+        [[IMYWebLoader defaultAjaxHandler] startWithMethod:method
+                                                       url:urlString
+                                                   baseURL:self.webView.URL
+                                                   headers:requestHeaders
+                                                      body:requestData
+                                            completedBlock:^(NSInteger httpCode, NSDictionary * _Nullable headers, NSString * _Nullable data) {
+                                                [self requestCallback:requestID httpCode:httpCode headers:headers data:data];
+                                            }];
+        
+    }];
+    
+   
 }
 
 - (void)requestCallback:(id)requestId httpCode:(NSInteger)httpCode headers:(NSDictionary *)headers data:(NSString *)data


### PR DESCRIPTION
Hi，li6185377
这个库挺好用的，感谢作者的无私奉献~！！
我在项目中使用的时候发现拦截的Ajax没有附带浏览器的UA，导致我们业务后端误判为PC端的请求。我觉得这个问题应该算是这个库的一个小漏洞，所以打了一个patch，希望作者能merge并更新pod。
再次感谢！！